### PR TITLE
アイコンURLをフォールバックで取得

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -219,6 +219,14 @@ func (s *SlackHandler) messageHandle(ev *slackevents.MessageEvent) {
 		name = user.RealName
 	}
 
+	var icon = user.Profile.ImageOriginal
+	if icon == "" {
+		icon = user.Profile.Image512
+	}
+	if icon == "" {
+		icon = user.Profile.Image192
+	}
+
 	// send file links by webhook
 	for _, f := range files {
 		text += "\n" + f.Permalink
@@ -290,7 +298,7 @@ func (s *SlackHandler) messageHandle(ev *slackevents.MessageEvent) {
 			}
 
 			var message = slack_webhook.Message{
-				IconURL:     user.Profile.ImageOriginal,
+				IconURL:     icon,
 				Username:    name,
 				Channel:     ev.Channel,
 				Text:        content,


### PR DESCRIPTION
Slack API の `users.info` ですが、レスポンスに `user.profile.image_original` が入っていない場合があります。

(@ryokohbato の例)

```jsonc
{
  "ok": true,
  "user": {
    "id": "U01U7S3UFAB",
    // 中略
    "first_name": "ryokohbato",
    "last_name": "",
    "image_24": "https://secure.gravatar.com/avatar/6996b24c010206efe7de9ceeece7cc82.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0022-24.png",
    "image_32": "https://secure.gravatar.com/avatar/6996b24c010206efe7de9ceeece7cc82.jpg?s=32&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0022-32.png",
    "image_48": "https://secure.gravatar.com/avatar/6996b24c010206efe7de9ceeece7cc82.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0022-48.png",
    "image_72": "https://secure.gravatar.com/avatar/6996b24c010206efe7de9ceeece7cc82.jpg?s=72&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0022-72.png",
    "image_192": "https://secure.gravatar.com/avatar/6996b24c010206efe7de9ceeece7cc82.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0022-192.png",
    "image_512": "https://secure.gravatar.com/avatar/6996b24c010206efe7de9ceeece7cc82.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0022-512.png",
    "status_text_canonical": "",
    "team": "T0321RSJ5"
    },
    // 略
  }
}
```

この場合、アイコンをフォールバックで取得していく必要があります。現時点では192までしか書いていませんが、それ以下が必要になる場合もあるかもしれません。
